### PR TITLE
github repository url in npm is incorrect

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/raythree/redux-action-binder.git"
+    "url": "git+https://github.com/raythree/redux-promise-resolver.git"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
Switched from redux-action-binder to this repository.
